### PR TITLE
pm2 versions fixed to support node 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Install / upgrade **(on the master machine only)**:
 
 ```
-bash <(curl -s https://raw.githubusercontent.com/LiquidGalaxyLAB/liquid-galaxy-api/master/scripts/install.sh)
+bash <(curl -s https://raw.githubusercontent.com/Rohit-554/liquid-galaxy-api/refs/heads/master/scripts/install.sh)
 ```
 
 The API will be available under port **82** (proxy served by Apache). http://localhost:82 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Install / upgrade **(on the master machine only)**:
 
 ```
-bash <(curl -s https://raw.githubusercontent.com/Rohit-554/liquid-galaxy-api/refs/heads/master/scripts/install.sh)
+bash <(curl -s https://raw.githubusercontent.com/LiquidGalaxyLAB/liquid-galaxy-api/master/scripts/install.sh)
 ```
 
 The API will be available under port **82** (proxy served by Apache). http://localhost:82 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,123 @@ Run with:
 
 You might need to create an iptables TCP exception. The API is running under port **3030** by default.
 
+
+# Troubleshooting (16.04 Lts)
+While running the script if you face issues follow the guide below
+
+# **Sudo/Local Node version**
+
+1. Check for sudo and Local node versions of node
+    
+    ```bash
+    sudo node -v
+    ```
+    
+    ```bash
+    node -v
+    ```
+    
+    Normally you should get this version for **Both** 
+    
+    ```bash
+    v8.xx.x
+    ```
+    
+
+1. If you get the error 
+    
+    ```bash
+    node: /lib/x86_64-linux-gnu/libm.so.6: version `glibc_2.27' not found (required by node)
+    ```
+    
+    **Solution**
+    
+    1. Check for which user you are getting it and then **follow this tutorial** to remove the NodeJS version 
+    
+    [How can I completely uninstall nodejs, npm and node in Ubuntu](https://stackoverflow.com/questions/32426601/how-can-i-completely-uninstall-nodejs-npm-and-node-in-ubuntu)
+    
+    b.  Then, install Node 8 using the below command
+    
+    ```
+    curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
+    ```
+    
+    ```
+    sudo apt-get install -qq nodejs
+    ```
+    
+    c. After that install Npm 
+    
+    ```
+    sudo apt-get install npm
+    ```
+    
+    d. install the script Again
+    
+    ```bash
+    bash <(curl -s [https://raw.githubusercontent.com/LiquidGalaxyLAB/liquid-galaxy-api/master/scripts/install.sh](https://raw.githubusercontent.com/LiquidGalaxyLAB/liquid-galaxy-api/master/scripts/install.sh))
+    ```
+    
+
+ e. check logs 
+
+```bash
+sudo pm2 log
+```
+
+If you can see API listening on port 3030 , Hit [**http://localhost:82**](http://localhost:82)
+
+```bash
+[TAILING] Tailing last 15 lines for [all] processes (change the value with --lines option)
+/home/lg/.pm2/pm2.log last 15 lines:
+...
+/home/lg/.pm2/logs/api-error.log last 15 lines:
+...
+0|api      | WARNING: See https://github.com/lorenwest/node-config/wiki/Strict-Mode
+0|api      | Tue, 07 Jan 2025 21:59:20 GMT info -·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-
+0|api      | Tue, 07 Jan 2025 21:59:20 GMT info 🌐  API listening on port 3030
+0|api      | Tue, 07 Jan 2025 21:59:20 GMT info -·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-·-
+0|api      | Tue, 07 Jan 2025 21:59:24 GMT info [Firebase] Signed in as BJIvaloH1l (no password)
+0|api      | Tue, 07 Jan 2025 22:08:55 GMT info ::1 - - [07/Jan/2025:22:08:55 +0000] "GET / HTTP/1.1" 304 - "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+```
+
+# Pm2 Version Mismatch
+
+1. If you get this Error while installing the script that 
+
+```bash
+Pm2 Version (In Memory) 5.3.1
+Pm2 version 3.5.1
+```
+
+Follow this Tutorial :
+
+[Can't update(uninstall/install) pm2 version 0.7.8](https://stackoverflow.com/questions/37524927/cant-updateuninstall-install-pm2-version-0-7-8)
+
+Then, check below
+
+**Solution**
+
+1. uninstall the version
+
+```bash
+sudo npm uninstall pm2
+```
+
+b. Install the **3.5.1** version
+
+```bash
+sudo npm install pm2@3.5.1 -g
+```
+
+c. install the script Again
+
+```bash
+bash <(curl -s [https://raw.githubusercontent.com/LiquidGalaxyLAB/liquid-galaxy-api/master/scripts/install.sh](https://raw.githubusercontent.com/LiquidGalaxyLAB/liquid-galaxy-api/master/scripts/install.sh))
+```
+
+Follow Step “e” above
+
 ## License
 
 MIT © [Gerard Rovira Sánchez](//zurfyx.com)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,80 +2,71 @@
 # API installation / upgrade script for Liquid Galaxy.
 TARGET_DIR="$HOME/api"
 SOURCE_CODE="https://github.com/LiquidGalaxyLab/liquid-galaxy-api"
-
-if [ "$EUID" -eq 0 ]; then
-  echo "Do not run as root!"
+if [ "$EUID" -eq 0 ]
+  then echo "Do not run as root!"
   exit
 fi
-
 apache2=$(which apache2)
 if [ "$apache2" = "" ]; then
   echo "Apache2 installation was not found. Make sure you are running this script on the Liquid Galaxy master."
   exit;
 fi
-
 # Apache port.
 echo "NameVirtualHost *:82" | sudo tee -a /etc/apache2/ports.conf > /dev/null
 echo "Listen 82" | sudo tee -a /etc/apache2/ports.conf > /dev/null
-
 # API Apache configuration.
 sudo a2enmod proxy proxy_http rewrite
 sudo tee "/etc/apache2/sites-available/api.conf" > /dev/null << EOM
 <VirtualHost *:82>
-    RewriteEngine On
-    RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
-    RewriteCond %{QUERY_STRING} transport=websocket    [NC]
-    RewriteRule /(.*)           ws://localhost:3001/$1 [P,L]
-    ProxyRequests off
-    <Proxy *>
-        Order deny,allow
-        Allow from all
-    </Proxy>
-    <Location />    
-        ProxyPass http://localhost:3030/
-        ProxyPassReverse http://localhost:3030/
-    </Location>
+	RewriteEngine On
+	RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
+	RewriteCond %{QUERY_STRING} transport=websocket    [NC]
+	RewriteRule /(.*)           ws://localhost:3001/$1 [P,L]
+	ProxyRequests off
+	<Proxy *>
+		Order deny,allow
+		Allow from all
+	</Proxy>
+	<Location />	
+		ProxyPass http://localhost:3030/
+		ProxyPassReverse http://localhost:3030/
+	</Location>
 </VirtualHost>
 EOM
-
 sudo a2ensite api.conf
 sudo /etc/init.d/apache2 reload
 sudo iptables -I INPUT 1 -p tcp --dport 82 -j ACCEPT
 sudo iptables-save | sudo tee /etc/iptables.conf > /dev/null
 
-# Install Node.js 8.x
-curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
+# Install Node.js 14.x instead of 8.x
+echo "Installing Node.js 14.x..."
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 sudo apt-get install -qq nodejs
-
-# Clean PM2 installation
-echo "Cleaning up existing PM2 installation..."
-pm2 kill 2>/dev/null || true
-sudo npm uninstall -g pm2 2>/dev/null || true
-rm -rf ~/.pm2 2>/dev/null || true
-rm -rf /usr/lib/node_modules/pm2 2>/dev/null || true
-npm cache clean --force
 
 # Install specific PM2 version
 echo "Installing PM2 version 3.5.1..."
 sudo npm install pm2@3.5.1 -g
 
-# Verify PM2 installation
+# Verify PM2 version
 PM2_VERSION=$(pm2 -v)
-echo "Installed PM2 version: $PM2_VERSION"
-
-if [ -d "$TARGET_DIR" ]; then
-    pm2 delete api 2>/dev/null || true
-else
-    git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
+if [ "$PM2_VERSION" != "3.5.1" ]; then
+    echo "Warning: PM2 version mismatch. Forcing version 3.5.1..."
+    sudo npm install -g pm2@3.5.1
+    PM2_VERSION=$(pm2 -v)
+    echo "PM2 version now: $PM2_VERSION"
 fi
 
+if [ -d "$TARGET_DIR" ]; then
+	pm2 delete api 2>/dev/null || true
+else
+	git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
+fi
 (
   cd "$TARGET_DIR"
-    git pull
-    npm install
-    pm2 --name api start npm -- start
-    pm2 save
+	git pull
+  npm install
+  pm2 --name api start npm -- start
+	pm2 save
 )
-
 sudo env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u "$(whoami)" --hp "/home/$(whoami)"
 echo "You're all set!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,20 +47,23 @@ sudo iptables-save | sudo tee /etc/iptables.conf > /dev/null
 curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 sudo apt-get install -qq nodejs
 
-# Downgrade PM2 to specific version
-echo "Downgrading PM2 to version 3.5.1..."
-pm2 kill 2>/dev/null || true
+# Install specific PM2 version
+echo "Installing PM2 version 3.5.1..."
 sudo npm install pm2@3.5.1 -g
 
-# Verify PM2 installation
+# Verify PM2 version and enforce if needed
 PM2_VERSION=$(pm2 -v)
-echo "Installed PM2 version: $PM2_VERSION"
+if [ "$PM2_VERSION" != "3.5.1" ]; then
+    echo "Warning: PM2 version mismatch. Forcing version 3.5.1..."
+    sudo npm install -g pm2@3.5.1
+fi
 
 if [ -d "$TARGET_DIR" ]; then
   pm2 delete api 2>/dev/null || true
 else
   git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
 fi
+
 (
   cd "$TARGET_DIR"
   git pull

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,7 +51,7 @@ sudo iptables-save | sudo tee /etc/iptables.conf > /dev/null
 
 curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 sudo apt-get install -qq nodejs
-sudo npm install pm2@4.5.6 -g
+sudo npm install pm2@4.0.1 -g
 
 if [ -d "$TARGET_DIR" ]; then
 	pm2 delete api

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,26 +2,30 @@
 # API installation / upgrade script for Liquid Galaxy.
 TARGET_DIR="$HOME/api"
 SOURCE_CODE="https://github.com/LiquidGalaxyLab/liquid-galaxy-api"
+
 if [ "$EUID" -eq 0 ]; then
   echo "Do not run as root!"
   exit
 fi
+
 apache2=$(which apache2)
 if [ "$apache2" = "" ]; then
   echo "Apache2 installation was not found. Make sure you are running this script on the Liquid Galaxy master."
   exit;
 fi
+
 # Apache port.
 echo "NameVirtualHost *:82" | sudo tee -a /etc/apache2/ports.conf > /dev/null
 echo "Listen 82" | sudo tee -a /etc/apache2/ports.conf > /dev/null
+
 # API Apache configuration.
 sudo a2enmod proxy proxy_http rewrite
 sudo tee "/etc/apache2/sites-available/api.conf" > /dev/null << EOM
-<VirtualHost :82>
+<VirtualHost *:82>
     RewriteEngine On
     RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
     RewriteCond %{QUERY_STRING} transport=websocket    [NC]
-    RewriteRule /(.)           ws://localhost:3001/$1 [P,L]
+    RewriteRule /(.*)           ws://localhost:3001/$1 [P,L]
     ProxyRequests off
     <Proxy *>
         Order deny,allow
@@ -33,13 +37,16 @@ sudo tee "/etc/apache2/sites-available/api.conf" > /dev/null << EOM
     </Location>
 </VirtualHost>
 EOM
+
 sudo a2ensite api.conf
 sudo /etc/init.d/apache2 reload
 sudo iptables -I INPUT 1 -p tcp --dport 82 -j ACCEPT
 sudo iptables-save | sudo tee /etc/iptables.conf > /dev/null
+
 # Install Node.js 8.x
 curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 sudo apt-get install -qq nodejs
+
 # Clean PM2 installation
 echo "Cleaning up existing PM2 installation..."
 pm2 kill 2>/dev/null || true
@@ -47,17 +54,21 @@ sudo npm uninstall -g pm2 2>/dev/null || true
 rm -rf ~/.pm2 2>/dev/null || true
 rm -rf /usr/lib/node_modules/pm2 2>/dev/null || true
 npm cache clean --force
+
 # Install specific PM2 version
 echo "Installing PM2 version 3.5.1..."
 sudo npm install pm2@3.5.1 -g
+
 # Verify PM2 installation
 PM2_VERSION=$(pm2 -v)
 echo "Installed PM2 version: $PM2_VERSION"
+
 if [ -d "$TARGET_DIR" ]; then
     pm2 delete api 2>/dev/null || true
 else
     git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
 fi
+
 (
   cd "$TARGET_DIR"
     git pull
@@ -65,5 +76,6 @@ fi
     pm2 --name api start npm -- start
     pm2 save
 )
+
 sudo env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u "$(whoami)" --hp "/home/$(whoami)"
 echo "You're all set!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,16 +47,9 @@ sudo iptables-save | sudo tee /etc/iptables.conf > /dev/null
 curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 sudo apt-get install -qq nodejs
 
-# Clean PM2 installation
-echo "Cleaning up existing PM2 installation..."
+# Downgrade PM2 to specific version
+echo "Downgrading PM2 to version 3.5.1..."
 pm2 kill 2>/dev/null || true
-sudo npm uninstall -g pm2 2>/dev/null || true
-rm -rf ~/.pm2 2>/dev/null || true
-rm -rf /usr/lib/node_modules/pm2 2>/dev/null || true
-npm cache clean --force
-
-# Install specific PM2 version
-echo "Installing PM2 version 3.5.1..."
 sudo npm install pm2@3.5.1 -g
 
 # Verify PM2 installation
@@ -64,17 +57,16 @@ PM2_VERSION=$(pm2 -v)
 echo "Installed PM2 version: $PM2_VERSION"
 
 if [ -d "$TARGET_DIR" ]; then
-    pm2 delete api 2>/dev/null || true
+  pm2 delete api 2>/dev/null || true
 else
-    git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
+  git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
 fi
-
 (
   cd "$TARGET_DIR"
-    git pull
-    npm install
-    pm2 --name api start npm -- start
-    pm2 save
+  git pull
+  npm install
+  pm2 --name api start npm -- start
+  pm2 save
 )
 
 sudo env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u "$(whoami)" --hp "/home/$(whoami)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,7 +51,7 @@ sudo iptables-save | sudo tee /etc/iptables.conf > /dev/null
 
 curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 sudo apt-get install -qq nodejs
-sudo npm install pm2@4.0.1 -g
+sudo npm install pm2@3.5.1 -g
 
 if [ -d "$TARGET_DIR" ]; then
 	pm2 delete api

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,48 +2,41 @@
 # API installation / upgrade script for Liquid Galaxy.
 TARGET_DIR="$HOME/api"
 SOURCE_CODE="https://github.com/LiquidGalaxyLab/liquid-galaxy-api"
-
-if [ "$EUID" -eq 0 ]; then
-  echo "Do not run as root!"
+if [ "$EUID" -eq 0 ]
+  then echo "Do not run as root!"
   exit
 fi
-
 apache2=$(which apache2)
 if [ "$apache2" = "" ]; then
   echo "Apache2 installation was not found. Make sure you are running this script on the Liquid Galaxy master."
   exit;
 fi
-
 # Apache port.
 echo "NameVirtualHost *:82" | sudo tee -a /etc/apache2/ports.conf > /dev/null
 echo "Listen 82" | sudo tee -a /etc/apache2/ports.conf > /dev/null
-
 # API Apache configuration.
 sudo a2enmod proxy proxy_http rewrite
 sudo tee "/etc/apache2/sites-available/api.conf" > /dev/null << EOM
 <VirtualHost *:82>
-    RewriteEngine On
-    RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
-    RewriteCond %{QUERY_STRING} transport=websocket    [NC]
-    RewriteRule /(.*)           ws://localhost:3001/$1 [P,L]
-    ProxyRequests off
-    <Proxy *>
-        Order deny,allow
-        Allow from all
-    </Proxy>
-    <Location />    
-        ProxyPass http://localhost:3030/
-        ProxyPassReverse http://localhost:3030/
-    </Location>
+	RewriteEngine On
+	RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
+	RewriteCond %{QUERY_STRING} transport=websocket    [NC]
+	RewriteRule /(.*)           ws://localhost:3001/$1 [P,L]
+	ProxyRequests off
+	<Proxy *>
+		Order deny,allow
+		Allow from all
+	</Proxy>
+	<Location />	
+		ProxyPass http://localhost:3030/
+		ProxyPassReverse http://localhost:3030/
+	</Location>
 </VirtualHost>
 EOM
-
 sudo a2ensite api.conf
 sudo /etc/init.d/apache2 reload
 sudo iptables -I INPUT 1 -p tcp --dport 82 -j ACCEPT
 sudo iptables-save | sudo tee /etc/iptables.conf > /dev/null
-
-# Install Node.js 8.x
 curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 sudo apt-get install -qq nodejs
 
@@ -51,26 +44,26 @@ sudo apt-get install -qq nodejs
 echo "Installing PM2 version 3.5.1..."
 sudo npm install pm2@3.5.1 -g
 
-# Verify PM2 version and enforce if needed
+# Verify PM2 version
 PM2_VERSION=$(pm2 -v)
 if [ "$PM2_VERSION" != "3.5.1" ]; then
     echo "Warning: PM2 version mismatch. Forcing version 3.5.1..."
     sudo npm install -g pm2@3.5.1
+    PM2_VERSION=$(pm2 -v)
+    echo "PM2 version now: $PM2_VERSION"
 fi
 
 if [ -d "$TARGET_DIR" ]; then
-  pm2 delete api 2>/dev/null || true
+	pm2 delete api 2>/dev/null || true
 else
-  git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
+	git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
 fi
-
 (
   cd "$TARGET_DIR"
-  git pull
+	git pull
   npm install
   pm2 --name api start npm -- start
-  pm2 save
+	pm2 save
 )
-
 sudo env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u "$(whoami)" --hp "/home/$(whoami)"
 echo "You're all set!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,8 @@
 # API installation / upgrade script for Liquid Galaxy.
 TARGET_DIR="$HOME/api"
 SOURCE_CODE="https://github.com/LiquidGalaxyLab/liquid-galaxy-api"
-if [ "$EUID" -eq 0 ]
-  then echo "Do not run as root!"
+if [ "$EUID" -eq 0 ]; then
+  echo "Do not run as root!"
   exit
 fi
 apache2=$(which apache2)
@@ -17,53 +17,53 @@ echo "Listen 82" | sudo tee -a /etc/apache2/ports.conf > /dev/null
 # API Apache configuration.
 sudo a2enmod proxy proxy_http rewrite
 sudo tee "/etc/apache2/sites-available/api.conf" > /dev/null << EOM
-<VirtualHost *:82>
-	RewriteEngine On
-	RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
-	RewriteCond %{QUERY_STRING} transport=websocket    [NC]
-	RewriteRule /(.*)           ws://localhost:3001/$1 [P,L]
-	ProxyRequests off
-	<Proxy *>
-		Order deny,allow
-		Allow from all
-	</Proxy>
-	<Location />	
-		ProxyPass http://localhost:3030/
-		ProxyPassReverse http://localhost:3030/
-	</Location>
+<VirtualHost :82>
+    RewriteEngine On
+    RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
+    RewriteCond %{QUERY_STRING} transport=websocket    [NC]
+    RewriteRule /(.)           ws://localhost:3001/$1 [P,L]
+    ProxyRequests off
+    <Proxy *>
+        Order deny,allow
+        Allow from all
+    </Proxy>
+    <Location />    
+        ProxyPass http://localhost:3030/
+        ProxyPassReverse http://localhost:3030/
+    </Location>
 </VirtualHost>
 EOM
 sudo a2ensite api.conf
 sudo /etc/init.d/apache2 reload
 sudo iptables -I INPUT 1 -p tcp --dport 82 -j ACCEPT
 sudo iptables-save | sudo tee /etc/iptables.conf > /dev/null
+# Install Node.js 8.x
 curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 sudo apt-get install -qq nodejs
-
+# Clean PM2 installation
+echo "Cleaning up existing PM2 installation..."
+pm2 kill 2>/dev/null || true
+sudo npm uninstall -g pm2 2>/dev/null || true
+rm -rf ~/.pm2 2>/dev/null || true
+rm -rf /usr/lib/node_modules/pm2 2>/dev/null || true
+npm cache clean --force
 # Install specific PM2 version
 echo "Installing PM2 version 3.5.1..."
 sudo npm install pm2@3.5.1 -g
-
-# Verify PM2 version
+# Verify PM2 installation
 PM2_VERSION=$(pm2 -v)
-if [ "$PM2_VERSION" != "3.5.1" ]; then
-    echo "Warning: PM2 version mismatch. Forcing version 3.5.1..."
-    sudo npm install -g pm2@3.5.1
-    PM2_VERSION=$(pm2 -v)
-    echo "PM2 version now: $PM2_VERSION"
-fi
-
+echo "Installed PM2 version: $PM2_VERSION"
 if [ -d "$TARGET_DIR" ]; then
-	pm2 delete api 2>/dev/null || true
+    pm2 delete api 2>/dev/null || true
 else
-	git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
+    git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
 fi
 (
   cd "$TARGET_DIR"
-	git pull
-  npm install
-  pm2 --name api start npm -- start
-	pm2 save
+    git pull
+    npm install
+    pm2 --name api start npm -- start
+    pm2 save
 )
 sudo env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u "$(whoami)" --hp "/home/$(whoami)"
 echo "You're all set!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,7 +51,7 @@ sudo iptables-save | sudo tee /etc/iptables.conf > /dev/null
 
 curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 sudo apt-get install -qq nodejs
-sudo npm install pm2 -g
+sudo npm install pm2@4.5.6 -g
 
 if [ -d "$TARGET_DIR" ]; then
 	pm2 delete api

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
-
 # API installation / upgrade script for Liquid Galaxy.
-
 TARGET_DIR="$HOME/api"
 SOURCE_CODE="https://github.com/LiquidGalaxyLab/liquid-galaxy-api"
 
-if [ "$EUID" -eq 0 ]
-  then echo "Do not run as root!"
+if [ "$EUID" -eq 0 ]; then
+  echo "Do not run as root!"
   exit
 fi
 
@@ -24,47 +22,60 @@ echo "Listen 82" | sudo tee -a /etc/apache2/ports.conf > /dev/null
 sudo a2enmod proxy proxy_http rewrite
 sudo tee "/etc/apache2/sites-available/api.conf" > /dev/null << EOM
 <VirtualHost *:82>
-	RewriteEngine On
-	RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
-	RewriteCond %{QUERY_STRING} transport=websocket    [NC]
-	RewriteRule /(.*)           ws://localhost:3001/$1 [P,L]
-
-	ProxyRequests off
-
-	<Proxy *>
-		Order deny,allow
-		Allow from all
-	</Proxy>
-
-	<Location />	
-		ProxyPass http://localhost:3030/
-		ProxyPassReverse http://localhost:3030/
-	</Location>
+    RewriteEngine On
+    RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
+    RewriteCond %{QUERY_STRING} transport=websocket    [NC]
+    RewriteRule /(.*)           ws://localhost:3001/$1 [P,L]
+    ProxyRequests off
+    <Proxy *>
+        Order deny,allow
+        Allow from all
+    </Proxy>
+    <Location />    
+        ProxyPass http://localhost:3030/
+        ProxyPassReverse http://localhost:3030/
+    </Location>
 </VirtualHost>
 EOM
+
 sudo a2ensite api.conf
-
 sudo /etc/init.d/apache2 reload
-
 sudo iptables -I INPUT 1 -p tcp --dport 82 -j ACCEPT
 sudo iptables-save | sudo tee /etc/iptables.conf > /dev/null
 
+# Install Node.js 8.x
 curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 sudo apt-get install -qq nodejs
+
+# Clean PM2 installation
+echo "Cleaning up existing PM2 installation..."
+pm2 kill 2>/dev/null || true
+sudo npm uninstall -g pm2 2>/dev/null || true
+rm -rf ~/.pm2 2>/dev/null || true
+rm -rf /usr/lib/node_modules/pm2 2>/dev/null || true
+npm cache clean --force
+
+# Install specific PM2 version
+echo "Installing PM2 version 3.5.1..."
 sudo npm install pm2@3.5.1 -g
 
+# Verify PM2 installation
+PM2_VERSION=$(pm2 -v)
+echo "Installed PM2 version: $PM2_VERSION"
+
 if [ -d "$TARGET_DIR" ]; then
-	pm2 delete api
+    pm2 delete api 2>/dev/null || true
 else
-	git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
+    git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
 fi
+
 (
   cd "$TARGET_DIR"
-	git pull
-  npm install
-  pm2 --name api start npm -- start
-	pm2 save
+    git pull
+    npm install
+    pm2 --name api start npm -- start
+    pm2 save
 )
-sudo env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u "$(whoami)" --hp "/home/$(whoami)"
 
+sudo env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u "$(whoami)" --hp "/home/$(whoami)"
 echo "You're all set!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,71 +2,80 @@
 # API installation / upgrade script for Liquid Galaxy.
 TARGET_DIR="$HOME/api"
 SOURCE_CODE="https://github.com/LiquidGalaxyLab/liquid-galaxy-api"
-if [ "$EUID" -eq 0 ]
-  then echo "Do not run as root!"
+
+if [ "$EUID" -eq 0 ]; then
+  echo "Do not run as root!"
   exit
 fi
+
 apache2=$(which apache2)
 if [ "$apache2" = "" ]; then
   echo "Apache2 installation was not found. Make sure you are running this script on the Liquid Galaxy master."
   exit;
 fi
+
 # Apache port.
 echo "NameVirtualHost *:82" | sudo tee -a /etc/apache2/ports.conf > /dev/null
 echo "Listen 82" | sudo tee -a /etc/apache2/ports.conf > /dev/null
+
 # API Apache configuration.
 sudo a2enmod proxy proxy_http rewrite
 sudo tee "/etc/apache2/sites-available/api.conf" > /dev/null << EOM
 <VirtualHost *:82>
-	RewriteEngine On
-	RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
-	RewriteCond %{QUERY_STRING} transport=websocket    [NC]
-	RewriteRule /(.*)           ws://localhost:3001/$1 [P,L]
-	ProxyRequests off
-	<Proxy *>
-		Order deny,allow
-		Allow from all
-	</Proxy>
-	<Location />	
-		ProxyPass http://localhost:3030/
-		ProxyPassReverse http://localhost:3030/
-	</Location>
+    RewriteEngine On
+    RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
+    RewriteCond %{QUERY_STRING} transport=websocket    [NC]
+    RewriteRule /(.*)           ws://localhost:3001/$1 [P,L]
+    ProxyRequests off
+    <Proxy *>
+        Order deny,allow
+        Allow from all
+    </Proxy>
+    <Location />    
+        ProxyPass http://localhost:3030/
+        ProxyPassReverse http://localhost:3030/
+    </Location>
 </VirtualHost>
 EOM
+
 sudo a2ensite api.conf
 sudo /etc/init.d/apache2 reload
 sudo iptables -I INPUT 1 -p tcp --dport 82 -j ACCEPT
 sudo iptables-save | sudo tee /etc/iptables.conf > /dev/null
 
-# Install Node.js 14.x instead of 8.x
-echo "Installing Node.js 14.x..."
-curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+# Install Node.js 8.x
+curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 sudo apt-get install -qq nodejs
+
+# Clean PM2 installation
+echo "Cleaning up existing PM2 installation..."
+pm2 kill 2>/dev/null || true
+sudo npm uninstall -g pm2 2>/dev/null || true
+rm -rf ~/.pm2 2>/dev/null || true
+rm -rf /usr/lib/node_modules/pm2 2>/dev/null || true
+npm cache clean --force
 
 # Install specific PM2 version
 echo "Installing PM2 version 3.5.1..."
 sudo npm install pm2@3.5.1 -g
 
-# Verify PM2 version
+# Verify PM2 installation
 PM2_VERSION=$(pm2 -v)
-if [ "$PM2_VERSION" != "3.5.1" ]; then
-    echo "Warning: PM2 version mismatch. Forcing version 3.5.1..."
-    sudo npm install -g pm2@3.5.1
-    PM2_VERSION=$(pm2 -v)
-    echo "PM2 version now: $PM2_VERSION"
-fi
+echo "Installed PM2 version: $PM2_VERSION"
 
 if [ -d "$TARGET_DIR" ]; then
-	pm2 delete api 2>/dev/null || true
+    pm2 delete api 2>/dev/null || true
 else
-	git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
+    git clone $SOURCE_CODE $TARGET_DIR # New installation -> clone source code repository.
 fi
+
 (
   cd "$TARGET_DIR"
-	git pull
-  npm install
-  pm2 --name api start npm -- start
-	pm2 save
+    git pull
+    npm install
+    pm2 --name api start npm -- start
+    pm2 save
 )
+
 sudo env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u "$(whoami)" --hp "/home/$(whoami)"
 echo "You're all set!"


### PR DESCRIPTION
Title: Fix PM2 Compatibility Issues and Improve Installation Process

Description:
This PR addresses the PM2 compatibility issues with Node.js 8.x and improves the overall installation process of the Liquid Galaxy API.

Changes made:
- Added thorough PM2 cleanup steps before installation to prevent version conflicts
- Specified PM2 version 3.5.1 which is compatible with Node.js 8.x
- Added PM2 version verification after installation
- Improved script output with status messages
- Added Troubleshoot guide 
https://wax-antimony-dff.notion.site/Troubleshooting-Lg_Server-17480c696a0180a58bf1e673ba609751?pvs=73

Problem solved:
Previously, the installation script was failing due to PM2 version incompatibility with Node.js 8.x, specifically causing "Unexpected token import" errors. This PR ensures a clean installation of a compatible PM2 version.

Testing:
- Tested on fresh Liquid Galaxy installation
- Verified API starts correctly on port 82
- Confirmed PM2 processes run without version-related errors
- Tested cleanup and reinstallation scenarios

 ScreenShots 
 
![image](https://github.com/user-attachments/assets/9c233abe-c771-42ad-8cf0-b7235ef5c90b)

